### PR TITLE
Remove unused dependencies

### DIFF
--- a/flash-waimai-generate/pom.xml
+++ b/flash-waimai-generate/pom.xml
@@ -26,6 +26,36 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
             <version>${spring.boot.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.transaction</groupId>
+                    <artifactId>javax.transaction-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-aop</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-jdbc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.atteo</groupId>


### PR DESCRIPTION
@enilu Hi, I am a user of project **_cn.enilu:flash-waimai-generate:1.0_**. I found that its pom file introduced **_55_** dependencies. However, among them, **_17_** libraries (**_30%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_cn.enilu:flash-waimai-generate:1.0_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.springframework.boot:spring-boot-autoconfigure:jar:2.1.1.RELEASE:compile
javax.xml.bind:jaxb-api:jar:2.3.1:compile
ch.qos.logback:logback-classic:jar:1.2.3:compile
javax.annotation:javax.annotation-api:jar:1.3.2:compile
javax.transaction:javax.transaction-api:jar:1.3:compile
javax.activation:javax.activation-api:jar:1.2.0:compile
org.springframework.boot:spring-boot:jar:2.1.1.RELEASE:compile
org.apache.logging.log4j:log4j-api:jar:2.11.1:compile
org.springframework.boot:spring-boot-starter-logging:jar:2.1.1.RELEASE:compile
ch.qos.logback:logback-core:jar:1.2.3:compile
com.zaxxer:HikariCP:jar:3.2.0:compile
org.springframework.boot:spring-boot-starter:jar:2.1.1.RELEASE:compile
org.apache.logging.log4j:log4j-to-slf4j:jar:2.11.1:compile
org.yaml:snakeyaml:jar:1.23:runtime
org.slf4j:jul-to-slf4j:jar:1.7.25:compile
org.springframework.boot:spring-boot-starter-aop:jar:2.1.1.RELEASE:compile
org.springframework.boot:spring-boot-starter-jdbc:jar:2.1.1.RELEASE:compile
</code></pre>